### PR TITLE
Corrected Contribute link, corrected workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -81,8 +81,8 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: lts/*
+          check-latest: true
           registry-url: https://registry.npmjs.org/
-          cache: npm
 
       - name: Set up Git user
         run: |
@@ -109,8 +109,8 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: lts/*
+          check-latest: true
           registry-url: https://npm.pkg.github.com/
-          cache: npm
 
       - name: Set up Git user
         run: |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -117,4 +117,4 @@ nav:
   - Website: https://netwk.pro
   - Contributing:
       - Code of Conduct: CODE_OF_CONDUCT.md
-      - CONTRIBUTING.md
+      - Contribute to Network Pro™: contributing.md


### PR DESCRIPTION
Removed `cache: npm` from publish jobs. Specified contributing.md in lowercase, since MkDocs is evidently case-sensitive.